### PR TITLE
Adding AS923 Band support for RAK2245

### DIFF
--- a/layers/chirpstack/meta-chirpstack/recipes-chirpstack/chirpstack-network-server/chirpstack-network-server/config/as923.toml
+++ b/layers/chirpstack/meta-chirpstack/recipes-chirpstack/chirpstack-network-server/chirpstack-network-server/config/as923.toml
@@ -1,0 +1,12 @@
+[general]
+log_level=4
+log_to_syslog=true
+
+[postgresql]
+dsn="postgres://chirpstack_ns:chirpstack_ns@localhost/chirpstack_ns?sslmode=disable"
+
+[network_server]
+net_id="000000"
+
+  [network_server.band]
+  name="AS923"

--- a/layers/chirpstack/meta-chirpstack/recipes-chirpstack/chirpstack-network-server/chirpstack-network-server/config/as923.toml
+++ b/layers/chirpstack/meta-chirpstack/recipes-chirpstack/chirpstack-network-server/chirpstack-network-server/config/as923.toml
@@ -10,3 +10,33 @@ net_id="000000"
 
   [network_server.band]
   name="AS923"
+
+  [[network_server.network_settings.extra_channels]]
+  frequency=923600000
+  min_dr=0
+  max_dr=5
+
+  [[network_server.network_settings.extra_channels]]
+  frequency=923800000
+  min_dr=0
+  max_dr=5
+
+  [[network_server.network_settings.extra_channels]]
+  frequency=924000000
+  min_dr=0
+  max_dr=5
+
+  [[network_server.network_settings.extra_channels]]
+  frequency=924200000
+  min_dr=0
+  max_dr=5
+
+  [[network_server.network_settings.extra_channels]]
+  frequency=924400000
+  min_dr=0
+  max_dr=5
+
+  [[network_server.network_settings.extra_channels]]
+  frequency=924600000
+  min_dr=0
+  max_dr=5

--- a/layers/targets/meta-raspberrypi/recipes-chirpstack/chirpstack-concentratord/files/sx1301/as923_0.toml
+++ b/layers/targets/meta-raspberrypi/recipes-chirpstack/chirpstack-concentratord/files/sx1301/as923_0.toml
@@ -1,0 +1,20 @@
+# LoRa concentrator configuration.
+[gateway.concentrator]
+
+# Multi spreading-factor channels (LoRa).
+multi_sf_channels=[
+  923200000,
+  923400000,
+  923600000,
+  923800000,
+  924000000,
+  924200000,
+  924400000,
+  924600000,
+]
+
+# LoRa std channel (single spreading-factor).
+[gateway.concentrator.lora_std]
+frequency=924500000
+bandwidth=250000
+spreading_factor=7

--- a/layers/targets/meta-raspberrypi/recipes-core/gateway-config/files/gateway-config.sh
+++ b/layers/targets/meta-raspberrypi/recipes-core/gateway-config/files/gateway-config.sh
@@ -132,15 +132,17 @@ do_setup_rak831() {
         1 "EU868" \
         2 "AU915" \
         3 "US915" \
+        4 "AS923" \
         3>&1 1>&2 2>&3)
     RET=$?
     if [ $RET -eq 1 ]; then
         do_main_menu
     elif [ $RET -eq 0 ]; then
         case "$FUN" in
-			1) do_copy_concentratord_config "sx1301" "generic_eu868" "GNSS" "eu868" "0" && do_copy_chirpstack_ns_config "eu868";;
+			      1) do_copy_concentratord_config "sx1301" "generic_eu868" "GNSS" "eu868" "0" && do_copy_chirpstack_ns_config "eu868";;
             2) do_select_au915_block "sx1301" "generic_au915_gps";;
             3) do_select_us915_block "sx1301" "generic_us915_gps";;
+            4) do_select_as923_block "sx1301" "rak_2245_as923" "GNSS";;
         esac
     fi
 }
@@ -256,6 +258,23 @@ do_select_au915_block() {
 }
 
 
+do_select_as923_block() {
+  # $1: concentratord version
+	# $2: model
+	# $3: model flags
+    FUN=$(dialog --title "Channel-plan configuration" --menu "Select the AS923 channel-block:" 15 60 8 \
+        1 "Channels  0 -  7 + 64" \
+        3>&1 1>&2 2>&3)
+    RET=$?
+    if [ $RET -eq 1 ]; then
+        do_main_menu
+    elif [ $RET -eq 0 ]; then
+        case "$FUN" in
+            1) do_copy_concentratord_config $1 $2 $3 "as923" "0" && do_copy_chirpstack_ns_config "as923";;
+        esac
+    fi
+}
+
 do_set_concentratord() {
 	monit stop chirpstack-concentratord
 	sed -i "s/CONCENTRATORD_VERSION=.*/CONCENTRATORD_VERSION=\"$1\"/" /etc/default/chirpstack-concentratord
@@ -301,7 +320,7 @@ do_copy_concentratord_config() {
         RET=$?
         if [ $RET -eq 0 ]; then
 			# set model
-			sed -i "s/model=.*/model=\"${2}\"/" /etc/chirpstack-concentratord/$1/global.toml	
+			sed -i "s/model=.*/model=\"${2}\"/" /etc/chirpstack-concentratord/$1/global.toml
 
 			# set model flags
 			IFS=' '; read -ra model_flags <<< $3
@@ -414,7 +433,7 @@ quit" 25 60
 }
 
 if [ $EUID -ne 0 ]; then
-   echo "This script must be run as root" 
+   echo "This script must be run as root"
    exit 1
 fi
 

--- a/layers/targets/meta-raspberrypi/recipes-core/gateway-config/files/gateway-config.sh
+++ b/layers/targets/meta-raspberrypi/recipes-core/gateway-config/files/gateway-config.sh
@@ -142,7 +142,7 @@ do_setup_rak831() {
 			      1) do_copy_concentratord_config "sx1301" "generic_eu868" "GNSS" "eu868" "0" && do_copy_chirpstack_ns_config "eu868";;
             2) do_select_au915_block "sx1301" "generic_au915_gps";;
             3) do_select_us915_block "sx1301" "generic_us915_gps";;
-            4) do_select_as923_block "sx1301" "rak_2245_as923" "GNSS";;
+            4) do_copy_concentratord_config "sx1301" "rak_2245_as923" "GNSS" "as923" "0" && do_copy_chirpstack_ns_config "as923";;
         esac
     fi
 }
@@ -253,24 +253,6 @@ do_select_au915_block() {
             6) do_copy_concentratord_config $1 $2 $3 "au915" "5" && do_copy_chirpstack_ns_config "au915_5";;
             7) do_copy_concentratord_config $1 $2 $3 "au915" "6" && do_copy_chirpstack_ns_config "au915_6";;
             8) do_copy_concentratord_config $1 $2 $3 "au915" "7" && do_copy_chirpstack_ns_config "au915_7";;
-        esac
-    fi
-}
-
-
-do_select_as923_block() {
-  # $1: concentratord version
-	# $2: model
-	# $3: model flags
-    FUN=$(dialog --title "Channel-plan configuration" --menu "Select the AS923 channel-block:" 15 60 8 \
-        1 "Channels  0 -  7 + 64" \
-        3>&1 1>&2 2>&3)
-    RET=$?
-    if [ $RET -eq 1 ]; then
-        do_main_menu
-    elif [ $RET -eq 0 ]; then
-        case "$FUN" in
-            1) do_copy_concentratord_config $1 $2 $3 "as923" "0" && do_copy_chirpstack_ns_config "as923";;
         esac
     fi
 }


### PR DESCRIPTION
### Contribution description
Can be seen in https://github.com/brocaar/chirpstack-gateway-os/issues/41

Include the following tasks: 

- Adds toml configuration to select AS923 at chirpstack-concentratord level.
- Creates do_select_as923_block function with GNSS enabled by default. 
- Generates toml configuration to selecct AS923 at chirpstack-network-server level. 
