### PR TITLE
Fix bootfiles path in rpi-config

### DIFF
--- a/layers/targets/meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/layers/targets/meta-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -1,19 +1,19 @@
 do_deploy_append() {
-    echo "dtparam=spi=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt    
-    echo "enable_uart=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "dtparam=i2c1=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "dtparam=i2c_arm=on" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    echo "dtparam=spi=on" >>${DEPLOYDIR}/bootfiles/config.txt    
+    echo "enable_uart=1" >>${DEPLOYDIR}/bootfiles/config.txt
+    echo "dtparam=i2c1=on" >>${DEPLOYDIR}/bootfiles/config.txt
+    echo "dtparam=i2c_arm=on" >>${DEPLOYDIR}/bootfiles/config.txt
 }
 
 do_deploy_append_raspberrypi3() {
-    echo "core_freq=250" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
-    echo "dtoverlay=pi3-disable-bt" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    echo "core_freq=250" >>${DEPLOYDIR}/bootfiles/config.txt
+    echo "dtoverlay=pi3-disable-bt" >>${DEPLOYDIR}/bootfiles/config.txt
 }
 
 do_deploy_append_raspberrypi4() {
-    echo "dtoverlay=disable-bt" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    echo "dtoverlay=disable-bt" >>${DEPLOYDIR}/bootfiles/config.txt
 }
 
 do_deploy_append_raspberrypi0-wifi() {
-    echo "dtoverlay=disable-bt" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+    echo "dtoverlay=disable-bt" >>${DEPLOYDIR}/bootfiles/config.txt
 }


### PR DESCRIPTION
Getting following Error on build, paths are unified in latest version of yocto.
```
ERROR: rpi-config-git-r5 do_deploy: Execution of '/home/dennis/chirpstack-gateway-os/build/tmp/raspberrypi/raspberrypi3-glibc/work/raspberrypi3-oe-linux-gnueabi/rpi-config/git-r5/temp/run.do_deploy.28664' failed with exit code 2:
/home/dennis/chirpstack-gateway-os/build/tmp/raspberrypi/raspberrypi3-glibc/work/raspberrypi3-oe-linux-gnueabi/rpi-config/git-r5/temp/run.do_deploy.28664: 291: /home/dennis/chirpstack-gateway-os/build/tmp/raspberrypi/raspberrypi3-glibc/work/raspberrypi3-oe-linux-gnueabi/rpi-config/git-r5/temp/run.do_deploy.28664: cannot create /home/dennis/chirpstack-gateway-os/build/tmp/raspberrypi/raspberrypi3-glibc/work/raspberrypi3-oe-linux-gnueabi/rpi-config/git-r5/deploy-rpi-config/bcm2835-bootfiles/config.txt: Directory nonexistent
WARNING: exit code 2 from a shell command.

ERROR: Logfile of failure stored in: /home/dennis/chirpstack-gateway-os/build/tmp/raspberrypi/raspberrypi3-glibc/work/raspberrypi3-oe-linux-gnueabi/rpi-config/git-r5/temp/log.do_deploy.28664
```